### PR TITLE
Add Lumos case study (litigation finance marketplace)

### DIFF
--- a/src/content/work/lumos.md
+++ b/src/content/work/lumos.md
@@ -1,0 +1,90 @@
+---
+title: "Lumos"
+client: "Lumos"
+description: "A secure marketplace for litigation finance — connecting litigants with funders through an invite-only platform built on trust, verification, and a curated community."
+category: finance
+date: 2023-03-01
+image: /images/work/lumos/featured.jpg
+imageAlt: "Lumos — Secure litigation finance marketplace"
+status: "Live"
+partnership: "4 months"
+services:
+  - Product Strategy
+  - Market Analysis
+  - Product Design
+  - Full-Stack Development
+metrics:
+  deliveries: 38
+  timeline: "4 months"
+  accuracy: "95%"
+  cycleTime: "4.8d"
+  onTime: "95%"
+testimonial:
+  quote: ""
+  author: "Madeleine Wykstra"
+  role: "Founder, Lumos"
+team:
+  - name: "Madeleine Wykstra"
+    role: "Founder"
+platforms:
+  - Web
+phases:
+  - name: "Discovery"
+    duration: "4 weeks"
+  - name: "Build"
+    duration: "12 weeks"
+---
+
+## The Bet
+
+Litigation finance is a growing market — but one still running on relationships, phone calls, and opaque deal flow. Founder Madeleine Wykstra saw the gap: litigants who needed funding had no efficient way to connect with funders, and funders had no structured way to evaluate and invest in cases. Both sides operated without transparency, security, or choice.
+
+Madeleine came to Nolte with a vision for a digital marketplace that would serve both parties — and an existing version that wasn't working. The platform was buggy, unresponsive to user needs, and nowhere near market-ready. She needed a partner who could rethink the product from the ground up and deliver a robust MVP that would earn trust in an industry where trust is everything.
+
+## The Complexity
+
+This wasn't a standard two-sided marketplace. Litigation finance sits at the intersection of legal, financial, and regulatory worlds:
+
+- **Dual-sided trust problem** — both litigants and funders need verification, privacy, and confidence that the other party is legitimate. A marketplace where either side doesn't trust the platform is dead on arrival.
+- **Invite-only access model** — not an open marketplace. A curated community with rigorous verification to maintain quality and security.
+- **Sensitive data handling** — litigation details, financial information, and personal data all require careful security architecture.
+- **Two distinct user experiences** — lawyers and investors have fundamentally different workflows, mental models, and priorities. One product has to serve both.
+
+## The Thinking
+
+We started with a one-month discovery phase — not just requirements gathering, but the strategic work that would determine whether the product had a viable path to market.
+
+**Market analysis** — We mapped the litigation finance ecosystem, analyzed competitors, and identified the specific gaps Lumos could own. The insight: existing platforms competed on deal volume. Lumos could compete on trust and curation.
+
+**Customer profiling** — Demographics and psychographics for both sides of the marketplace. Investors wanted deal flow quality and due diligence support. Case holders wanted transparency and control over their funding process. These profiles shaped every design decision.
+
+**User interviews** — Direct conversations with potential users on both sides revealed unmet needs the existing product hadn't addressed. The feedback confirmed the trust thesis and exposed specific friction points in how litigants and funders evaluate each other.
+
+**Design and tech evaluation** — We proposed a fresh design concept and recommended a modern tech stack (TypeScript with NestJS and NextJS, PostgreSQL) to replace the existing codebase entirely. A rebuild, not a patch.
+
+## The Build
+
+With the strategic foundation in place, we moved into a three-month execution phase. The team — software engineers, a product designer, a communication expert, and a product manager — worked in a Kanban-based cadence with frequent stakeholder sessions to keep Madeleine close to every decision.
+
+**Investor and litigant dashboards** — Separate views tailored to each user type. Investors see curated case opportunities with the information they need for due diligence. Litigants manage their cases and funding requests with full visibility into the process.
+
+**Verification and onboarding** — Rigorous identity verification flows for both sides of the marketplace. The invite-only model required a careful onboarding experience that maintained exclusivity without creating unnecessary friction.
+
+**User profiles and case management** — Structured profiles that let both parties present themselves credibly. Case management tools that organize the information funders need to make decisions.
+
+**Lumos UI Library** — A custom design system built for consistency across the platform. Every component reflects the trust and professionalism the brand demands.
+
+**Go-to-market landing page** — A waiting list mechanism to gauge market interest and build community before launch. The landing page was designed to communicate Lumos's value proposition and convert early adopters.
+
+## The Proof
+
+From a buggy existing product to a market-ready MVP in four months — rebuilt from the ground up with a modern tech stack, a curated marketplace model, and a user experience designed for an industry that demands trust above all else.
+
+- **38 deliveries** forecasted and shipped through NolteOS
+- **4-month** timeline from discovery through launch
+- **Complete rebuild** — new architecture, new design, new tech stack
+- **Two-sided marketplace** — separate experiences for litigants and funders, unified by a single trust model
+
+## The Partnership
+
+Lumos was a product rescue turned product launch. Madeleine came to us with a vision and a broken v1. We didn't patch what was there — we challenged the assumptions, validated the market thesis, and built something worth launching. The strategic work in discovery shaped a product that competes on trust and curation rather than trying to be everything to everyone.


### PR DESCRIPTION
## Summary
- Adds Lumos case study at `/work/lumos` — a secure, invite-only marketplace for litigation finance built from a broken v1 into a market-ready MVP over 4 months
- Follows existing case study format with frontmatter metrics, phases, services, and structured narrative (The Bet / Complexity / Thinking / Build / Proof / Partnership)
- Filed under the `finance` category

**Note:** Metrics (38 deliveries, 95% accuracy, 4.8d cycle time) are estimated from the project scope — replace with real NolteOS data. Images, client logo, and testimonial quote are placeholder/empty.

## Test plan
- [ ] Verify `/work/lumos` renders correctly in dev
- [ ] Replace estimated metrics with real NolteOS delivery data
- [ ] Add featured image and any platform screenshots
- [ ] Add Lumos logo to `clientLogos` map in `[slug].astro`
- [ ] Fill in testimonial quote if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)