### PR TITLE
Use ending.jpg as Wake case study featured image

### DIFF
--- a/src/content/work/wake.md
+++ b/src/content/work/wake.md
@@ -4,8 +4,8 @@ client: "Wake"
 description: "A mental wellness platform built from strategy to market launch in four months — mobile apps for iOS and Android, an HR dashboard, and a scalable API for a pre-seed startup entering the B2B2C wellness space."
 category: wellness
 date: 2024-03-01
-image: /images/work/wake/featured.png
-imageAlt: "Wake mental wellness mobile app screens"
+image: /images/work/wake/ending.jpg
+imageAlt: "Wake mental wellness platform"
 status: "Pre-Seed"
 partnership: "18 months"
 services:


### PR DESCRIPTION
## Summary
- Swaps the Wake case study hero/featured image from `featured.png` to `ending.jpg` for a better visual on the case study page

## Test plan
- [ ] Verify `/work/wake` hero image renders correctly with `ending.jpg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)