### PR TITLE
Fix: Add redirect for old forecasting gap URL

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -63,6 +63,7 @@
 /budgeting-for-software-development-when-delivery-is-forecastable  /blog/budgeting-for-software-development  301
 /measuring-productivity-in-software-development  /blog/measuring-productivity-in-software-development  301
 /measuring-productivity-in-digital-product-development  /blog/measuring-productivity-in-software-development  301
+/the-forecasting-gap     /blog/the-predictability-gap  301
 /the-predictability-gap  /blog/the-predictability-gap  301
 
 # WordPress slugs with no matching Astro post (GSC 404s)


### PR DESCRIPTION
Fixes the broken redirect from `/the-forecasting-gap` to `/blog/the-predictability-gap`.

The blog post exists and had a redirect for `/the-predictability-gap`, but was missing the redirect for the older `/the-forecasting-gap` URL.

Closes #66

Generated with [Claude Code](https://claude.ai/code)